### PR TITLE
Refactor id to thing_id

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -33,11 +33,11 @@ app.get('/api/get-location', async (req, res) => {
   res.status(200).json(response)
 })
 
-app.get('/api/get-thing/:id', async (req, res) => {
-  const { id } = req.params
+app.get('/api/get-thing/:thing_id', async (req, res) => {
+  const { thing_id } = req.params
 
   const thing = await fetch(
-    `https://iot.hamburg.de/v1.0/Things(${id})/Datastreams`
+    `https://iot.hamburg.de/v1.0/Things(${thing_id})/Datastreams`
   ).then((res) => res.json())
 
   const dataStream_id = thing.value[0]['@iot.id']
@@ -61,7 +61,7 @@ app.get('/api/get-thing/:id', async (req, res) => {
     dataStream_id,
     availableBikes,
     lastUpdated,
-    thing_id: id,
+    thing_id,
   }
   res.status(200).json(response)
 })

--- a/server.js
+++ b/server.js
@@ -38,11 +38,11 @@ app.get('/api/get-location', async (req, res) => {
   res.status(200).json(response)
 })
 
-app.get('/api/get-thing/:id', async (req, res) => {
-  const { id } = req.params
+app.get('/api/get-thing/:thing_id', async (req, res) => {
+  const { thing_id } = req.params
 
   const thing = await fetch(
-    `https://iot.hamburg.de/v1.0/Things(${id})/Datastreams`
+    `https://iot.hamburg.de/v1.0/Things(${thing_id})/Datastreams`
   ).then((res) => res.json())
 
   const dataStream_id = thing.value[0]['@iot.id']
@@ -66,7 +66,7 @@ app.get('/api/get-thing/:id', async (req, res) => {
     dataStream_id,
     availableBikes,
     lastUpdated,
-    thing_id: id,
+    thing_id,
   }
   res.status(200).json(response)
 })

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ function App() {
     <>
       <Header />
       <Switch>
-        <Route path="/thing/:id">
+        <Route path="/thing/:thing_id">
           <Thing toggleFavorit={toggleFavorit} favorites={favorites} />
         </Route>
         <Route path="/search">

--- a/src/components/Favorite.js
+++ b/src/components/Favorite.js
@@ -8,28 +8,21 @@ import { RiHeart3Fill } from 'react-icons/ri'
 import removeFirstWordFromStationName from '../utils/formatStationDescription'
 import getLocalTime from '../utils/getLocalTime'
 
-export default function Favorite({ id, toggleFavorit }) {
-  const { isLoading, error, data } = useQuery(['fetchThing', id], () =>
-    fetchThing(id)
+export default function Favorite({ thing_id, toggleFavorit }) {
+  const { isLoading, error, data } = useQuery(['fetchThing', thing_id], () =>
+    fetchThing(thing_id)
   )
 
   if (isLoading) return 'Loading...'
 
   if (error) return 'An error has occurred: ' + error.message
 
-  const {
-    station_description,
-    dataStream_id,
-    coordinates,
-    availableBikes,
-    lastUpdated,
-    thing_id,
-  } = data
+  const { station_description, coordinates, availableBikes, lastUpdated } = data
 
   const title = removeFirstWordFromStationName(station_description)
 
   function handleClick() {
-    toggleFavorit(dataStream_id)
+    toggleFavorit(thing_id)
   }
 
   return (

--- a/src/hooks/useFavorite.js
+++ b/src/hooks/useFavorite.js
@@ -24,13 +24,11 @@ export default function useFavorite() {
   // helper functions
 
   function isFavorite(id) {
-    return (
-      favorites.filter((favorite) => favorite.dataStream_id === id).length > 0
-    )
+    return favorites.filter((favorite) => favorite.thing_id === id).length > 0
   }
 
   function removeFavorite(id) {
-    setFavorites(favorites.filter((favorite) => favorite.dataStream_id !== id))
+    setFavorites(favorites.filter((favorite) => favorite.thing_id !== id))
   }
 
   function addFavorite(newFavorite) {

--- a/src/pages/Favorites.js
+++ b/src/pages/Favorites.js
@@ -10,7 +10,7 @@ export default function Favorites({ favorites, toggleFavorit }) {
         favorites.map((fav) => (
           <Favorite
             key={fav.station_description}
-            id={fav.id}
+            thing_id={fav.thing_id}
             toggleFavorit={toggleFavorit}
           />
         ))

--- a/src/pages/Thing.js
+++ b/src/pages/Thing.js
@@ -10,33 +10,25 @@ import { IconContext } from 'react-icons'
 import getLocalTime from '../utils/getLocalTime'
 
 export default function Thing({ toggleFavorit, favorites }) {
-  const { id } = useParams()
+  const { thing_id } = useParams()
   const history = useHistory()
 
-  const { isLoading, error, data } = useQuery(['fetchThing', id], () =>
-    fetchThing(id)
+  const { isLoading, error, data } = useQuery(['fetchThing', thing_id], () =>
+    fetchThing(thing_id)
   )
 
   if (isLoading) return 'Loading...'
 
   if (error) return 'An error has occurred: ' + error.message
 
-  const {
-    station_description,
-    dataStream_id,
-    coordinates,
-    availableBikes,
-    lastUpdated,
-  } = data
+  const { station_description, coordinates, availableBikes, lastUpdated } = data
 
   function handleOnClick() {
-    toggleFavorit(dataStream_id, { ...data, id })
+    toggleFavorit(thing_id, { station_description, thing_id })
   }
 
   const title = removeFirstWordFromStationName(station_description)
-  const isStationFav = favorites.some(
-    (fav) => fav.dataStream_id === dataStream_id
-  )
+  const isStationFav = favorites.some((fav) => fav.thing_id === thing_id)
 
   return (
     <Wrapper>


### PR DESCRIPTION
## Description

This pr refactors removes a dependency, where the logic was dependent from `datastream_id`. But this was not good, because this means the app has to do one more `fetch` operation to get the `datastream_id` if needed. I switch the dependency to `thing_id` because this doesn't need an extra fetch to get all information when comparing something.


## What was done here
- switch logic from datastream_id to thing_id
- will become easier to handle future logic
because we have always access to the thing_id and
everything is fetched through the thing_id, no need for datastream_id
- remove unused values from API respond
- update API files (server/index).js files to new naming as well