### PR TITLE
Add bike is pluralized when available bikes not 1

### DIFF
--- a/src/pages/Thing.js
+++ b/src/pages/Thing.js
@@ -30,6 +30,7 @@ export default function Thing({ toggleFavorit, isFavorite }) {
   const title = removeFirstWordFromStationName(station_description) || ''
   const isStationFav = isFavorite(thing_id) || ''
   const { availableColor } = getAvailabilityInfos()
+  const isPlural = getIsPlural(availableBikes)
   return (
     <Wrapper>
       <Blue />
@@ -63,7 +64,7 @@ export default function Thing({ toggleFavorit, isFavorite }) {
           ) : (
             <>
               <Count availableColor={availableColor}>{availableBikes}</Count>
-              Fahrräder
+              {isPlural ? 'Fahrräder' : 'Fahrrad'}
             </>
           )}
         </Bikes>
@@ -97,6 +98,10 @@ export default function Thing({ toggleFavorit, isFavorite }) {
       availableColor = 'red'
     }
     return { isBikeAvailable, availableColor }
+  }
+
+  function getIsPlural(availableBikes) {
+    return availableBikes !== 1
   }
 }
 


### PR DESCRIPTION
# Description
This pr adds a `pluralization` function to the `Thing` component. When the number `availableBikes` is 1 the component renders the singular form "Fahrrad". If 0 or bigger than 1 it renders the plural form "Fahrräder".