### PR TITLE
Fix filtered list is covered from navbar

### DIFF
--- a/src/pages/SearchStations.js
+++ b/src/pages/SearchStations.js
@@ -69,6 +69,7 @@ const ResultWrapper = styled.div`
 const ResultList = styled.ul`
   list-style: none;
   padding: 0;
+  margin-bottom: 155px;
 `
 
 const Wrapper = styled.div`


### PR DESCRIPTION
# Description
This pr fixes #21 

Just added a margin-bottom to the filtered `list`.