### PR TITLE
Fix filtered list in search station renders strange

### DIFF
--- a/src/pages/SearchStations.js
+++ b/src/pages/SearchStations.js
@@ -43,7 +43,7 @@ export default function SearchStations({ isFavorite, toggleFavorit }) {
     const { station_description, thing_id } = location
     return (
       <Result
-        key={station_description}
+        key={thing_id}
         station_description={station_description}
         isFav={isFavorite(thing_id)}
         thing_id={thing_id}


### PR DESCRIPTION
# Description
This pr fixes #22.

I just changed the `key` prop to a more unique value `thing_id`. Was `station_description` and there are more stations with the same name. This caused the problem in the `map()` and in the rendered list.